### PR TITLE
Adds ESS support to the InferenceResult object

### DIFF
--- a/examples/crbd.tppl
+++ b/examples/crbd.tppl
@@ -1,12 +1,7 @@
-type Tree =
-  | Leaf {age: Real}
-  | Node {left: Tree, right: Tree, age: Real}
-
 function simulateSubtree(time: Real, lambda: Real, mu: Real) {
   assume waitingTime ~ Exponential(lambda + mu);
   if waitingTime > time {
-    weight 0.0;
-    resample;
+    weight 0.0; resample;
   } else {
     assume isSpeciation ~ Bernoulli(lambda / (lambda + mu));
     if isSpeciation {
@@ -20,7 +15,7 @@ function walk(node: Tree, time:Real, lambda: Real, mu: Real) {
   assume waitingTime ~ Exponential(lambda);
   if time - waitingTime > node.age {
     simulateSubtree(time - waitingTime, lambda, mu);
-    weight 2.0;
+    weight 2.0; // Unaligned. likelihood resampling will not work
     observe 0 ~ Poisson(mu * waitingTime);
     walk(node, time - waitingTime, lambda, mu);
   } else {

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='treeppl',
-    version='0.1',
+    version='0.2',
     description='Python Interface to TreePPL',
     author='Jan Kudlicka',
     author_email='github@kudlicka.eu',


### PR DESCRIPTION
We can compute the effective sample size with `res.ess()` now, where `res` is the result of calling of calling the inference with the `treeppl.Model`.

Previously I was thinking of including this function in the `treeppl-python-utlils` package, but I think the logic is better stored here, as it is a method of the `InferenceResult` class.

There is a limitation right now: the TreePPL model can return a `Real` or a `Real[]`.  Still useful for the majority of cases.

Example:

```
...

tree = treeppl.Tree.load("trees/Alcedinidae.phyjson", format="phyjson")

with treeppl.Model(filename="crbd.tppl", samples=10_000) as crbd:
    while True:
        res = crbd(tree=tree)
        print(res.ess())
        plt.pause(0.05)
```