### PR TITLE
Handle changes in Python 3.14

### DIFF
--- a/treeppl/base.py
+++ b/treeppl/base.py
@@ -42,7 +42,11 @@ def get_tpplc_binary():
     if not os.path.isdir(tppl_dir_path):
         with importlib.resources.path('treeppl', tarball_name) as tarball:
             with tarfile.open(tarball) as tar:
-                tar.extractall(tmp_dir)
+                if hasattr(tarfile, 'tar_filter'):
+                    tar.extractall(tmp_dir, filter='tar')
+                else:
+                    # NOTE(vipa, 2025-11-20): This allows us to support Python < 3.12
+                    tar.extractall(tmp_dir)
     return os.path.join(tppl_dir_path, "tpplc")
 
 class Model:


### PR DESCRIPTION
Python 3.14 changes the defaults for tarfile in such a way that it doesn't support all things in tar. This change makes us request enough features that it works for us.