### PR TITLE
Don't automatically add --resample, since it makes it impossible to run with non-smc

### DIFF
--- a/treeppl/base.py
+++ b/treeppl/base.py
@@ -76,8 +76,6 @@ class Model:
             args.append(f"--{k.replace('_', '-')}")
             if v is not True:
                 args.append(str(v))
-        if not "resample" in kwargs:
-            args.extend(["--resample", "align"])
         with Popen(
             args=args, cwd=self.temp_dir.name, stdout=PIPE, stderr=STDOUT
         ) as proc:


### PR DESCRIPTION
Fixes #12.

Generally speaking we probably want to expose the flags directly, and not change their defaults relative to the executable, i.e., if we want other defaults we should change them there.