### PR TITLE
Always use the self-contained tpplc, never one from PATH

### DIFF
--- a/treeppl/base.py
+++ b/treeppl/base.py
@@ -13,10 +13,8 @@ from .exceptions import CompileError, InferenceError
 from .serialization import from_json, to_json
 
 def get_tpplc_binary():
-    tpplc = shutil.which("tpplc")
-    if tpplc:
-        return tpplc
-
+    if os.environ.get('TPPLC'):
+        return os.environ['TPPLC']
     # NOTE(vipa, 2025-06-04): The selfcontained compiler must be
     # deployed to a directory somewhere. There are three important
     # limitatations:


### PR DESCRIPTION
This makes the treeppl-python package never look for `tpplc` on `PATH`, which should fix part of #9. To enable testing against locally built `tpplc` the library will now respect the `TPPLC` environment variable: if it is set, use that as the path to the binary.