### PR TITLE
Remove import of trees, given its implicit importing

### DIFF
--- a/examples/crbd.tppl
+++ b/examples/crbd.tppl
@@ -1,5 +1,3 @@
-import "treeppl::lib/trees.tppl"
-
 type alias Tree = ClockTree
 
 function simulateExtinctSubtree(time: Real, lambda: Real, mu: Real) {

--- a/examples/treeppl_in_jupyter.ipynb
+++ b/examples/treeppl_in_jupyter.ipynb
@@ -227,8 +227,6 @@
    "outputs": [],
    "source": [
     "%%treeppl crbd -m smc-bpf --particles 10000 --resample align --subsample --subsample-size 10\n",
-    "import \"treeppl::lib/trees.tppl\"\n",
-    "\n",
     "type alias Tree = ClockTree\n",
     "\n",
     "function simulateExtinctSubtree(time: Real, lambda: Real, mu: Real) {\n",

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -46,8 +46,6 @@ def test_tree_input():
     )
     with treeppl.Model(
         source="""\
-import "treeppl::trees.tppl"
-
 type alias Tree = ClockTree
 
 function count_leaves(tree: Tree) => Int {


### PR DESCRIPTION
This fixes breakage caused by https://github.com/treeppl/treeppl/pull/153.