### PR TITLE
Add explicit import to importlib.resources

### DIFF
--- a/misc/packaging/treeppl-python.nix
+++ b/misc/packaging/treeppl-python.nix
@@ -5,7 +5,7 @@
 
 let
   distribution = "treeppl";
-  version = "0.4";
+  version = "0.4.1";
   os =
     if stdenv.hostPlatform.isLinux then "linux" else
     if stdenv.hostPlatform.isDarwin then "macosx_11_0" else

--- a/treeppl/base.py
+++ b/treeppl/base.py
@@ -6,6 +6,7 @@ import numpy as np
 import tarfile
 import os
 import importlib
+import importlib.resources
 import shlex
 
 from .exceptions import CompileError, InferenceError


### PR DESCRIPTION
Seems `importlib.resources` ends up implicitly imported on some machines, but not others, meaning we'd missed adding that explicitly.

---

Suggest bullets to add to [the changelog](https://treeppl.org/docs/changelog) below (under `###` headings), if any. A PR that has a user-visible change should have a bullet, even if it's, e.g., just a bugfix.

## TreePPL Release Notes

### Added

### Changed

### Deprecated

### Removed

### Fixed

- Added missing import of `importlib.resources`, which would be implicitly imported on some machines, but not all.

### Security
